### PR TITLE
cmd: update nopt to parse filter args as arrays

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -8,9 +8,9 @@ const chalk = require('chalk')
 const knownOpts = { help: Boolean
                   , version: Boolean
                   , quiet: Boolean
-                  , 'file-filter': [String]
-                  , 'dir-filter': [String]
-                  , excludes: [String]
+                  , 'file-filter': [String, Array]
+                  , 'dir-filter': [String, Array]
+                  , excludes: [String, Array]
                   }
 const shortHand = { h: ['--help']
                   , v: ['--version']


### PR DESCRIPTION
The filter and excludes options were defined as an enum of String
types and were always being passed as the last value if the option was
specified more than once

```
-d !node_modules -d !.git -d !tools -> {dir-filter: "tools"}
```

Adding the Array type so nopt parses the values as an array of supplied
values

```
-d !node_modules -d !.git !tools -> {dir-filter: ["!node_modules", "!.git", "!tools"]}
```
Semver: patch